### PR TITLE
feat(docs): allow OV code signing certificates for official releases

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -149,6 +149,7 @@ The Log Notarization System is particularly valuable in scenarios such as:
 - **Competitive gaming verification**: Showing unmodified session data
 - **Legal proceedings**: Providing cryptographically verifiable evidence
 
+
 ## Enhanced Chain-of-Trust Authentication (v1.0.1+)
 
 Starting from version 1.0.1, Focus Game Deck implements an **Enhanced Chain-of-Trust Authentication System** that not only proves log integrity but also verifies the **authenticity of the application** that generated the logs.
@@ -174,7 +175,7 @@ The enhanced system creates a **cryptographic chain of trust** by recording:
 
 ```text
 [Signed .exe] → [Digital Signature] → [Certificate Hash] → [Firebase Record]
-     ↓                                                           ↑
+  ↓                                                           ↑
 [Log Generation] → [SHA256 Hash] → [Combined with App Hash] → [Upload]
 ```
 
@@ -198,9 +199,10 @@ Each notarized record now contains:
 }
 ```
 
+
 ### Official Signature Registry
 
-All official releases maintain a registry of authentic signature hashes in [`docs/official_signature_hashes.json`](docs/official_signature_hashes.json):
+All official releases are signed with a code signing certificate (EV or OV) and maintain a registry of authentic signature hashes in [`docs/official_signature_hashes.json`](docs/official_signature_hashes.json):
 
 ```json
 {
@@ -225,6 +227,7 @@ All official releases maintain a registry of authentic signature hashes in [`doc
 }
 ```
 
+
 ### Verification Process (Enhanced)
 
 To verify a log file with chain-of-trust authentication:
@@ -232,18 +235,18 @@ To verify a log file with chain-of-trust authentication:
 1. **Obtain Certificate ID** from user
 2. **Query Firebase record** using Certificate ID
 3. **Extract authentication data**:
-   - `logHash`: Used for log integrity verification
-   - `appSignatureHash`: Used for application authenticity verification
-   - `appVersion`: Used to locate official registry entry
+  - `logHash`: Used for log integrity verification
+  - `appSignatureHash`: Used for application authenticity verification
+  - `appVersion`: Used to locate official registry entry
 4. **Verify log integrity**: Calculate SHA256 of log file, compare with `logHash`
 5. **Verify application authenticity**:
-   - Look up `appVersion` in `docs/official_signature_hashes.json`
-   - Find the matching executable entry
-   - Compare `appSignatureHash` with registry entry
+  - Look up `appVersion` in `docs/official_signature_hashes.json`
+  - Find the matching executable entry
+  - Compare `appSignatureHash` with registry entry (EV or OV certificate)
 6. **Assessment**:
-   - **Fully Authentic**: Both hashes match official registry
-   - **Content Valid, Source Unknown**: Log hash valid but app signature not in registry
-   - **Invalid**: Log hash doesn't match file content
+  - **Fully Authentic**: Both hashes match official registry
+  - **Content Valid, Source Unknown**: Log hash valid but app signature not in registry
+  - **Invalid**: Log hash doesn't match file content
 
 ### Development vs Production Signatures
 

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -211,7 +211,19 @@ The Focus Game Deck architecture consists of five main layers, each serving dist
 - **Extensibility**: WebSocket API integration foundation for future model control features
 - **Platform Agnostic**: Supports both Steam and standalone VTube Studio installations
 
-#### 7. WebSocket Manager Architecture: Hybrid Utility Class Pattern
+
+#### 7. Code Signing Certificate Selection
+
+**Initial Consideration:**
+
+- The ideal choice was an Extended Validation (EV) certificate, aiming for the highest level of trust and SmartScreen compatibility.
+
+**Practical Decision:**
+
+- However, obtaining an EV certificate proved to be extremely difficult for an individual developer or sole proprietor due to strict requirements and verification processes.
+- As a realistic alternative, an Organization Validation (OV) certificate was selected. This option provides sufficient trust for code signing and SmartScreen reputation, while being attainable for small businesses and individual developers.
+
+#### 8. WebSocket Manager Architecture: Hybrid Utility Class Pattern
 
 **Problem Context:**
 

--- a/docs/developer-guide/build-system.md
+++ b/docs/developer-guide/build-system.md
@@ -136,16 +136,18 @@ Master-Build.ps1 (Tier 3: Orchestration)
 
 ## Digital Signature Infrastructure
 
+
 ### Certificate Requirements
 
-- **Type**: Extended Validation (EV) Code Signing Certificate
+- **Type**: Code Signing Certificate (EV or OV)
 - **Recommended Providers**: DigiCert, Sectigo, GlobalSign, Entrust
 - **Key Usage**: Digital Signature, Key Encipherment
 - **Extended Key Usage**: Code Signing
 
+
 ### Certificate Setup Process
 
-1. **Obtain EV Certificate**: Purchase from trusted Certificate Authority
+1. **Obtain EV or OV Certificate**: Purchase from a trusted Certificate Authority
 2. **Install Certificate**: Import into Windows Certificate Store (CurrentUser/My)
 3. **Configure Thumbprint**: Update `certificateThumbprint` in signing-config.json
 4. **Enable Signing**: Set `enabled: true` in configuration


### PR DESCRIPTION
Update security and build documentation to permit both EV and OV code signing certificates for official releases. Clarify certificate requirements and setup instructions to reflect this policy change.

## Description
Brief description of changes

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Testing
- [ ] Tests pass locally
- [ ] Added new tests (if applicable)
- [ ] Manual testing completed

## Checklist
- [ ] Code follows project standards
- [ ] Self-review completed
- [x] Documentation updated
- [ ] No breaking changes (or clearly documented)